### PR TITLE
fix: load and save parameters/workflow fields when editing a post

### DIFF
--- a/src/app/pages/upload/upload.page.ts
+++ b/src/app/pages/upload/upload.page.ts
@@ -280,6 +280,14 @@ export class UploadPage extends ResponsiveComponent implements OnInit {
                 temporaryAttachment.description = photo.description;
                 temporaryAttachment.blurhash = photo.blurhash;
 
+                if (photo.showParameters) {
+                    temporaryAttachment.parameters = photo.parameters;
+                }
+
+                if (photo.showWorkflow) {
+                    temporaryAttachment.workflow = photo.workflow;
+                }
+
                 if (photo.showMake) {
                     temporaryAttachment.make = photo.make;
                 }
@@ -516,6 +524,18 @@ export class UploadPage extends ResponsiveComponent implements OnInit {
                 uploadPhoto.description = caption.trim();
             }
 
+            const parameters = tags["parameters"]?.description.toString();
+            if (parameters) {
+              uploadPhoto.parameters = parameters;
+              uploadPhoto.showParameters = true;
+            }
+
+            const workflow = tags["workflow"]?.description.toString();
+            if (workflow) {
+              uploadPhoto.workflow = workflow;
+              uploadPhoto.showWorkflow = true;
+            }
+
             const make = tags['Make']?.description.toString();
             if (make) {
                 uploadPhoto.make = make;
@@ -704,6 +724,8 @@ export class UploadPage extends ResponsiveComponent implements OnInit {
 
                 const internalExif = attachment.metadata?.exif;
                 if (internalExif) {
+                    uploadPhoto.parameters = internalExif.parameters;
+                    uploadPhoto.workflow = internalExif.workflow;
                     uploadPhoto.make = internalExif.make;
                     uploadPhoto.model = internalExif.model;
                     uploadPhoto.lens = internalExif.lens;
@@ -725,6 +747,8 @@ export class UploadPage extends ResponsiveComponent implements OnInit {
                     }
                 }
 
+                uploadPhoto.showParameters = !!uploadPhoto.parameters;
+                uploadPhoto.showWorkflow = !!uploadPhoto.workflow;
                 uploadPhoto.showMake = !!uploadPhoto.make;
                 uploadPhoto.showModel = !!uploadPhoto.model;
                 uploadPhoto.showLens = !!uploadPhoto.lens;


### PR DESCRIPTION
## Summary

When editing a post, the `parameters` and `workflow` EXIF metadata fields were being silently wiped because:

1. **Load path missing** -- `loadStatusData()` never read `parameters` or `workflow` from the exif metadata when populating the edit form, and `showParameters`/`showWorkflow` were never set to `true`. The fields always loaded as empty.
2. **Save path missing** -- The save loop that builds `TemporaryAttachment` objects never conditionally included `parameters` or `workflow` based on the `showParameters`/`showWorkflow` flags.
3. **EXIF extraction missing** -- When uploading a new image, the EXIF reader never extracted `parameters` or `workflow` tags from the file.

All other metadata fields (make, model, software, film, chemistry, scanner, etc.) had these three code paths but `parameters` and `workflow` were missed.

## Changes

All in `src/app/pages/upload/upload.page.ts`:

- Add `uploadPhoto.parameters = internalExif.parameters` and `uploadPhoto.workflow = internalExif.workflow` in the `loadStatusData()` exif block
- Add `uploadPhoto.showParameters = !!uploadPhoto.parameters` and `uploadPhoto.showWorkflow = !!uploadPhoto.workflow` alongside the other show-flag assignments
- Add conditional save of `temporaryAttachment.parameters` and `temporaryAttachment.workflow` in the save loop
- Add EXIF tag extraction for `parameters` and `workflow` when reading tags from an uploaded image file

Fixes mchaker/VernissageWeb#3